### PR TITLE
fix(handler): add conditional check for containerRef before unbinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svelte-plugins/tooltips",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "description": "A simple tooltip action and component designed for Svelte.",
   "author": "Kieran Boyle (https://github.com/dysfunc)",

--- a/src/tooltip.svelte
+++ b/src/tooltip.svelte
@@ -80,8 +80,10 @@
       component = null;
     }
 
-    containerRef.removeEventListener('mouseenter', onMouseEnter);
-    containerRef.removeEventListener('mouseleave', onMouseLeave);
+    if (containerRef !== null) {
+      containerRef.removeEventListener('mouseenter', onMouseEnter);
+      containerRef.removeEventListener('mouseleave', onMouseLeave);
+    }
   });
 
   $: isComponent = typeof content === 'object';


### PR DESCRIPTION
This fixes an issue where errors occur due to a bad ref with SveltKit pre-rendering

Fixes #2 

CC: @TheRealThor