### PR TITLE
refactor(tooltips): use absolute v. relative tooltip positioning

### DIFF
--- a/docs/src/App.svelte
+++ b/docs/src/App.svelte
@@ -54,7 +54,7 @@
   </div>
 
 	<div class="example">
-		<p>This tooltip should appear to the <u use:tooltip={{ content: { component: ComponentAsContent, props: { title: 'Title from props' }}, position: 'left', style: { backgroundColor: 'blue' } }}>left</u> and render the passed component as the tooltip content.</p>
+		<p>This tooltip should appear to the <u use:tooltip={{ content: { component: ComponentAsContent, props: { title: 'Title from props' }}, position: 'left', animation: 'slide', style: { backgroundColor: 'blue' } }}>left</u> and render the passed component as the tooltip content.</p>
     <Prism showLineNumbers={true} code={`
 <script>
   import ComponentAsContent from './ComponentAsContent.svelte';
@@ -94,8 +94,9 @@
         position="right"
         action="click"
         theme="tooltip-theme">
-        <b>right</b> when clicked.
+        <b>right</b>
       </Tooltip>
+      when clicked.
     </p>
     <Prism showLineNumbers={true} code={`
 <Tooltip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svelte-plugins/tooltips",
-  "version": "0.1.8",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "A simple tooltip action and component designed for Svelte.",
   "author": "Kieran Boyle (https://github.com/dysfunc)",

--- a/src/action-tooltip.snap.js
+++ b/src/action-tooltip.snap.js
@@ -5,11 +5,12 @@ exports[`Components: Tooltip should render the component 1`] = `
   <div>
     <div
       class="tooltip animation-null top"
-      style="min-width: 200px; max-width: 200px; text-align: left;"
+      style="left: 0px; min-width: 200px; max-width: 200px; text-align: left; top: 0px;"
     >
       Hello World!
       
     </div>
+    
   </div>
 </body>
 `;

--- a/src/action-tooltip.svelte.d.ts
+++ b/src/action-tooltip.svelte.d.ts
@@ -2,35 +2,16 @@ import type { SvelteComponentTyped } from 'svelte';
 
 export interface ComponentProps {
   /**
-   * The content of the tooltip.
-   * @default ''
+   * The action to trigger the tooltip
+   * @default 'hover'
    */
-  content?: string;
+  action: 'hover' | 'click' | string;
 
   /**
-   * The position of the tooltip.
-   * Allowed values are 'top', 'bottom', 'left' or 'right'.
-   * @default 'top'
+   * The alignment of the tooltip.
+   * @default 'left'
    */
-  position?: string;
-
-  /**
-   * The maximum width of the tooltip.
-   * @default 200
-   */
-  maxWidth?: number;
-
-  /**
-   * The style of the tooltip.
-   * @default null
-   */
-  style?: undefined;
-
-  /**
-   * The theme of the tooltip.
-   * @default ''
-   */
-  theme?: string;
+  align?: 'left' | 'right' | 'center' | string;
 
   /**
    * The animation style of the tooltip.
@@ -45,10 +26,40 @@ export interface ComponentProps {
   arrow?: boolean;
 
   /**
-   * Whether to automatically position the tooltip.
+   * Whether to automatically position the tooltip when clipping occurs.
    * @default false
    */
   autoPosition?: boolean;
+
+  /**
+   * The content of the tooltip.
+   * @default ''
+   */
+  content?: string;
+
+  /**
+   * The maximum width of the tooltip.
+   * @default 200
+   */
+  maxWidth?: number;
+
+  /**
+   * The position of the tooltip.
+   * @default 'top'
+   */
+  position?: 'bottom' | 'left' | 'right' | 'top' | string;
+
+  /**
+   * The style of the tooltip.
+   * @default null
+   */
+  style?: undefined;
+
+  /**
+   * The theme of the tooltip.
+   * @default ''
+   */
+  theme?: string;
 }
 
 export default class Component extends SvelteComponentTyped<

--- a/src/action.js
+++ b/src/action.js
@@ -1,18 +1,18 @@
 import Tooltip from './action-tooltip.svelte';
 
 export const tooltip = (element, props) => {
-
   let component = null;
   let title = element.getAttribute('title');
   let action = props?.action || element.getAttribute('action') || 'hover';
 
+  const config = {
+    ...props,
+    targetElement: element
+  };
+
   if (title) {
     element.removeAttribute('title');
-
-    props = {
-      content: title,
-      ...props
-    }
+    config.content = title;
   }
 
   const onClick = () => {
@@ -27,7 +27,7 @@ export const tooltip = (element, props) => {
     if (!component) {
       component = new Tooltip({
         target: element,
-        props
+        props: config
       });
     }
   };
@@ -61,8 +61,6 @@ export const tooltip = (element, props) => {
   };
 
   addListeners();
-
-  element.style.position = 'relative';
 
   return {
     destroy() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,13 +18,57 @@ export const getMinWidth = (element, maxWidth) => {
   return Math.round(Math.min(maxWidth, contentWidth || maxWidth));
 };
 
-export const isInViewport = (element) => {
+export const isElementInViewport = (element, container = null) => {
   const rect = element.getBoundingClientRect();
 
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  );
+  let isAboveTop = rect.top >= 0;
+  let isBelowBottom = rect.bottom <= (window.innerHeight || document.documentElement.clientHeight);
+  let isLeftOfStart = rect.left >= 0;
+  let isRightOfEnd = rect.right <= (window.innerWidth || document.documentElement.clientWidth);
+
+  if (container) {
+    const containerRect = container.getBoundingClientRect();
+
+    isAboveTop = containerRect.top - rect.height >= 0;
+    isBelowBottom = containerRect.bottom + rect.height <= (window.innerHeight || document.documentElement.clientHeight);
+    isLeftOfStart = containerRect.left - rect.width >= 0;
+    isRightOfEnd = containerRect.right + rect.width <= (window.innerWidth || document.documentElement.clientWidth);
+
+    return isAboveTop && isBelowBottom && isLeftOfStart && isRightOfEnd;
+  }
+
+  return isAboveTop && isBelowBottom && isLeftOfStart && isRightOfEnd;
+};
+
+export const computeTooltipPosition = (containerRef, tooltipRef, position, coords) => {
+  if (!containerRef || !tooltipRef) {
+    return coords;
+  }
+
+  const containerRect = containerRef.getBoundingClientRect();
+  const tooltipRect = tooltipRef.getBoundingClientRect();
+
+  switch (position) {
+    case 'top':
+      coords.top = containerRect.top;
+      coords.left = containerRect.left + (containerRect.width / 2);
+      break;
+    case 'bottom':
+      coords.top = containerRect.top - tooltipRect.height;
+      coords.left = containerRect.left + (containerRect.width / 2);
+      break;
+    case 'left':
+      coords.left = containerRect.left;
+      coords.top = containerRect.top + (containerRect.height / 2);
+      break;
+    case 'right':
+      coords.left = containerRect.right - tooltipRect.width;
+      coords.top = containerRect.top + (containerRect.height / 2);
+      break;
+  }
+
+  coords.top += window.scrollY;
+  coords.left += window.scrollX;
+
+  return coords;
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,2 @@
-export { default } from "./tooltip.svelte";
+export { default as Tooltip } from './tooltip.svelte';
+export { tooltip } from './action';

--- a/src/tooltip.snap.js
+++ b/src/tooltip.snap.js
@@ -5,16 +5,15 @@ exports[`Components: Tooltip should render the component 1`] = `
   <div>
     <span
       class="tooltip-container"
+    />
+     
+    <div
+      class="tooltip animation-null top"
+      style="left: 0px; min-width: 200px; max-width: 200px; text-align: left; top: 0px;"
     >
-       
-      <div
-        class="tooltip animation-null top"
-        style="min-width: 200px; max-width: 200px; text-align: left;"
-      >
-        Hello World!
-        
-      </div>
-    </span>
+      Hello World!
+      
+    </div>
     
   </div>
 </body>

--- a/src/tooltip.svelte.d.ts
+++ b/src/tooltip.svelte.d.ts
@@ -2,35 +2,16 @@ import type { SvelteComponentTyped } from 'svelte';
 
 export interface ComponentProps {
   /**
-   * The content of the tooltip.
-   * @default ''
+   * The action to trigger the tooltip
+   * @default 'hover'
    */
-  content?: string;
+  action: 'hover' | 'click' | string;
 
   /**
-   * The position of the tooltip.
-   * Allowed values are 'top', 'bottom', 'left' or 'right'.
-   * @default 'top'
+   * The alignment of the tooltip.
+   * @default 'left'
    */
-  position?: string;
-
-  /**
-   * The maximum width of the tooltip.
-   * @default 200
-   */
-  maxWidth?: number;
-
-  /**
-   * The style of the tooltip.
-   * @default null
-   */
-  style?: undefined;
-
-  /**
-   * The theme of the tooltip.
-   * @default ''
-   */
-  theme?: string;
+  align?: 'left' | 'right' | 'center' | string;
 
   /**
    * The animation style of the tooltip.
@@ -45,10 +26,40 @@ export interface ComponentProps {
   arrow?: boolean;
 
   /**
-   * Whether to automatically position the tooltip.
+   * Whether to automatically position the tooltip when clipping occurs.
    * @default false
    */
   autoPosition?: boolean;
+
+  /**
+   * The content of the tooltip.
+   * @default ''
+   */
+  content?: string;
+
+  /**
+   * The maximum width of the tooltip.
+   * @default 200
+   */
+  maxWidth?: number;
+
+  /**
+   * The position of the tooltip.
+   * @default 'top'
+   */
+  position?: 'bottom' | 'left' | 'right' | 'top' | string;
+
+  /**
+   * The style of the tooltip.
+   * @default null
+   */
+  style?: undefined;
+
+  /**
+   * The theme of the tooltip.
+   * @default ''
+   */
+  theme?: string;
 }
 
 export default class Component extends SvelteComponentTyped<


### PR DESCRIPTION
This PR changes the current approach of tooltip placement from leveraging the target elements container to using the elements current position on the document.

Closes #7 

