### PR TITLE
refactor(tooltips): use absolute positioning with tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svelte-plugins/tooltips",
-  "version": "0.1.9",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "A simple tooltip action and component designed for Svelte.",
   "author": "Kieran Boyle (https://github.com/dysfunc)",

--- a/src/action-tooltip.snap.js
+++ b/src/action-tooltip.snap.js
@@ -5,7 +5,7 @@ exports[`Components: Tooltip should render the component 1`] = `
   <div>
     <div
       class="tooltip animation-null top"
-      style="min-width: 200px; max-width: 200px; text-align: left;"
+      style="left: 0px; min-width: 200px; max-width: 200px; text-align: left; top: 0px;"
     >
       Hello World!
       

--- a/src/action-tooltip.svelte.d.ts
+++ b/src/action-tooltip.svelte.d.ts
@@ -62,6 +62,12 @@ export interface ComponentProps {
   style?: undefined;
 
   /**
+   * The target element to bind the tooltip to.
+   * @default null
+   */
+  targetElement?: HTMLElement | null,
+
+  /**
    * The theme of the tooltip.
    * @default ''
    */

--- a/src/action.js
+++ b/src/action.js
@@ -5,13 +5,14 @@ export const tooltip = (element, props) => {
   let title = element.getAttribute('title');
   let action = props?.action || element.getAttribute('action') || 'hover';
 
+  const config = {
+    ...props,
+    targetElement: element
+  };
+
   if (title) {
     element.removeAttribute('title');
-
-    props = {
-      content: title,
-      ...props
-    }
+    config.content = title;
   }
 
   const onClick = () => {
@@ -26,7 +27,7 @@ export const tooltip = (element, props) => {
     if (!component) {
       component = new Tooltip({
         target: element,
-        props
+        props: config
       });
     }
   };
@@ -41,6 +42,10 @@ export const tooltip = (element, props) => {
   const addListeners = () => {
     if (element !== null) {
       removeListeners();
+
+      if (config.show) {
+        onShow();
+      }
 
       if (action === 'click') {
         element.addEventListener('click', onClick);
@@ -62,12 +67,6 @@ export const tooltip = (element, props) => {
   };
 
   addListeners();
-
-  element.style.position = 'relative';
-
-  if (props.show) {
-    onShow();
-  }
 
   return {
     destroy() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,13 +18,68 @@ export const getMinWidth = (element, maxWidth) => {
   return Math.round(Math.min(maxWidth, contentWidth || maxWidth));
 };
 
-export const isInViewport = (element) => {
+export const isElementInViewport = (element, container = null, position) => {
   const rect = element.getBoundingClientRect();
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
 
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  let isInsideViewport = (
+    rect.bottom > 0 &&
+    rect.top < viewportHeight &&
+    rect.right > 0 &&
+    rect.left < viewportWidth
   );
+
+  if (container) {
+    const containerRect = container.getBoundingClientRect();
+
+    if (position === 'top' || position === 'bottom') {
+      isInsideViewport = (
+        (containerRect.bottom + containerRect.height) < viewportHeight &&
+        containerRect.top < viewportHeight
+      );
+    } else {
+      isInsideViewport = (
+        (containerRect.right + containerRect.width) < viewportWidth &&
+        containerRect.left < viewportWidth
+      );
+    }
+
+    return isInsideViewport;
+  }
+
+  return isInsideViewport;
+};
+
+export const computeTooltipPosition = (containerRef, tooltipRef, position, coords) => {
+  if (!containerRef || !tooltipRef) {
+    return coords;
+  }
+
+  const containerRect = containerRef.getBoundingClientRect();
+  const tooltipRect = tooltipRef.getBoundingClientRect();
+
+  switch (position) {
+    case 'top':
+      coords.top = containerRect.top;
+      coords.left = containerRect.left + (containerRect.width / 2);
+      break;
+    case 'bottom':
+      coords.top = containerRect.top - tooltipRect.height;
+      coords.left = containerRect.left + (containerRect.width / 2);
+      break;
+    case 'left':
+      coords.left = containerRect.left;
+      coords.top = containerRect.top + (containerRect.height / 2);
+      break;
+    case 'right':
+      coords.left = containerRect.right - tooltipRect.width;
+      coords.top = containerRect.top + (containerRect.height / 2);
+      break;
+  }
+
+  coords.top += window.scrollY;
+  coords.left += window.scrollX;
+
+  return coords;
 };

--- a/src/tooltip.snap.js
+++ b/src/tooltip.snap.js
@@ -5,16 +5,15 @@ exports[`Components: Tooltip should render the component 1`] = `
   <div>
     <span
       class="tooltip-container"
+    />
+     
+    <div
+      class="tooltip animation-null top"
+      style="left: 0px; min-width: 200px; max-width: 200px; text-align: left; top: 0px;"
     >
-       
-      <div
-        class="tooltip animation-null top"
-        style="min-width: 200px; max-width: 200px; text-align: left;"
-      >
-        Hello World!
-        
-      </div>
-    </span>
+      Hello World!
+      
+    </div>
     
   </div>
 </body>


### PR DESCRIPTION
This changes the approach from leveraging the roots elements container to using the root elements position.

Fixes https://github.com/svelte-plugins/tooltips/issues/7 #13 