### PR TITLE
feat(tooltips): add delay prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Checkout out my <u use:tooltip={{ content: 'Hello World!' }}>tooltip</u>
 | :----------- | :------------------------------------------------------------------ | :---------------------------------------------- |
 | action       | The action that triggers the tooltip (hover | click | prop)         | `string` (default: `hover`)                     |
 | animation    | The animation to apply to the tooltip                               | `string` (default: ``)                          |
+| delay        | The animation delay in milliseconds to apply to the tooltip         | `number` (default: `200`)                       |
 | arrow        | If `false`, the tooltip arrow will not be shown.                    | `boolean` (default: `true`)                     |
 | autoPosition | Adjust tooltip position if viewport clipping occurs                 | `string` (default: `false`)                     |
 | content      | The string or object containing componentref and props              | `string` | `object` component (default: ``)     |

--- a/src/action-tooltip.svelte
+++ b/src/action-tooltip.svelte
@@ -32,6 +32,9 @@
   /** @type {string} */
   export let animation = '';
 
+  /** @type {number} */
+  export let delay = 200;
+
   /** @type {boolean} */
   export let arrow = true;
 
@@ -64,7 +67,7 @@
     left: 0
   };
 
-  const delay = animation ? 200 : 0;
+  const animationDelay = animation ? delay : 0;
 
   onMount(() => {
     if (tooltipRef !== null) {
@@ -97,7 +100,7 @@
       animationEffect = animation;
     }
 
-    setTimeout(() => (visible = true), delay);
+    setTimeout(() => (visible = true), animationDelay);
   });
 
   onDestroy(() => {
@@ -108,7 +111,7 @@
   });
 
   $: isComponent = typeof content === 'object';
-  $: tooltipRef && show ? setTimeout(() => (visible = true), delay) : (visible = false);
+  $: tooltipRef && show ? setTimeout(() => (visible = true), animationDelay) : (visible = false);
 </script>
 
 {#if content}

--- a/src/action-tooltip.svelte.d.ts
+++ b/src/action-tooltip.svelte.d.ts
@@ -20,6 +20,12 @@ export interface ComponentProps {
   animation?: string;
 
   /**
+   * The animation's delay of the tooltip.
+   * @default 200
+   */
+  delay?: number;
+
+  /**
    * Whether to show the arrow of the tooltip.
    * @default true
    */

--- a/src/tooltip.svelte
+++ b/src/tooltip.svelte
@@ -29,6 +29,9 @@
   /** @type {string} */
   export let animation = '';
 
+  /** @type {number} */
+  export let delay = 200;
+
   /** @type {boolean} */
   export let arrow = true;
 
@@ -79,7 +82,7 @@
   };
 
   const onShow = () => {
-    const delay = animation ? 200 : 0;
+    const animationDelay = animation ? delay : 0;
 
     // @ts-ignore
     if (autoPosition && !isElementInViewport(containerRef, tooltipRef, position)) {
@@ -93,7 +96,7 @@
       animationEffect = animation;
     }
 
-    timer = setTimeout(() => (visible = true), delay);
+    timer = setTimeout(() => (visible = true), animationDelay);
   };
 
   const onHide = () => {

--- a/src/tooltip.svelte.d.ts
+++ b/src/tooltip.svelte.d.ts
@@ -20,6 +20,12 @@ export interface ComponentProps {
   animation?: string;
 
   /**
+   * The animation's delay of the tooltip.
+   * @default 200
+   */
+  delay?: number;
+
+  /**
    * Whether to show the arrow of the tooltip.
    * @default true
    */


### PR DESCRIPTION
Hello! 👋

I've just made a tiny change here, nothing much. I felt the need to specify the animation's delay in some cases.

Changes made:

- Added a 'delay' prop to the tooltip component and action, defaulting to 200 milliseconds (ms).
- Included the prop types for both the component and action.

Please let me know the reasons for not including this prop if you have any!

Nice plugin, btw!