### PR TITLE
fix(helpers): position the tooltip relative to the offsetParent if it exists.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -57,24 +57,34 @@ export const computeTooltipPosition = (containerRef, tooltipRef, position, coord
   }
 
   const containerRect = containerRef.getBoundingClientRect();
+  let containerTop = containerRect.top;
+  let containerLeft = containerRect.left;
+
+  if (containerRef.offsetParent) {
+    // If there is an offsetParent, the containerRef could already be positioned differently than we expect. In this case, the tooltip's absolute positioning will be relative to the offsetParent, so we should ensure we don't let the offsetParent's rect positioning influence the tooltip's.
+    const parentRect = containerRef.offsetParent.getBoundingClientRect();
+    containerTop -= parentRect.top;
+    containerLeft -= parentRect.left;
+  }
+
   const tooltipRect = tooltipRef.getBoundingClientRect();
 
   switch (position) {
     case 'top':
-      coords.top = containerRect.top;
-      coords.left = containerRect.left + (containerRect.width / 2);
+      coords.top = containerTop;
+      coords.left = containerLeft + containerRect.width / 2;
       break;
     case 'bottom':
-      coords.top = containerRect.top - tooltipRect.height;
-      coords.left = containerRect.left + (containerRect.width / 2);
+      coords.top = containerTop - tooltipRect.height;
+      coords.left = containerLeft + containerRect.width / 2;
       break;
     case 'left':
-      coords.left = containerRect.left;
-      coords.top = containerRect.top + (containerRect.height / 2);
+      coords.left = containerLeft;
+      coords.top = containerTop + containerRect.height / 2;
       break;
     case 'right':
       coords.left = containerRect.right - tooltipRect.width;
-      coords.top = containerRect.top + (containerRect.height / 2);
+      coords.top = containerTop + containerRect.height / 2;
       break;
   }
 


### PR DESCRIPTION
Resolves #25.

If an `offsetParent` exists, we remove its rect positioning from the positioning that we calculate for the tooltip, because the tooltip's positioning will be relative to the `offsetParent`'s.
Note that in most cases, there will always be an `offsetParent` (which might just be the `body` element).

**How do we test?**

I haven't found any reasonable testing code in this package (and adding it would be outside the scope of this change), so I'd like to say I only tested this inside my own application (and confirmed that it fixes the positioning when there's a parent already with `position: absolute`). I could use some help verifying that this doesn't break any other use case. Worst case, I could wrap this change in a flag, and let users of this package opt-in to the fix.